### PR TITLE
Automatically base64 encode secrets and configs when plain text inserted

### DIFF
--- a/src/clj/swarmpit/docker/engine/mapper/outbound.clj
+++ b/src/clj/swarmpit/docker/engine/mapper/outbound.clj
@@ -251,9 +251,7 @@
 (defn ->secret
   [secret]
   {:Name (:secretName secret)
-   :Data (if (:encode secret)
-           (base64/encode (:data secret))
-           (:data secret))})
+   :Data (:data secret)})
 
 (defn ->config
   [config]

--- a/src/cljs/swarmpit/component/secret/create.cljs
+++ b/src/cljs/swarmpit/component/secret/create.cljs
@@ -46,16 +46,6 @@
        :onChange      (fn [_ v]
                         (state/update-value [:data] v state/form-value-cursor))})))
 
-(defn- form-data-encoder [value]
-  (form/comp
-    "ENCODE DATA"
-    (form/checkbox
-      {:name    "encoded"
-       :key     "encoded"
-       :checked value
-       :onCheck (fn [_ v]
-                  (state/update-value [:encode] v state/form-value-cursor))})))
-
 (defn- create-secret-handler
   []
   (ajax/post
@@ -80,8 +70,7 @@
 (defn- init-form-value
   []
   (state/set-value {:secretName nil
-                    :data       ""
-                    :encode     false} state/form-value-cursor))
+                    :data       ""} state/form-value-cursor))
 
 (def mixin-init-form
   (mixin/init-form
@@ -109,5 +98,4 @@
          :onInvalid #(state/update-value [:valid?] false state/form-state-cursor)}
         (html (form/icon-value icon/info "Data must be base64 encoded. If plain text check please encode data."))
         (form-name secretName)
-        (form-data-encoder encode)
         (form-data data))]]))


### PR DESCRIPTION
When user inserts plain text into config data, she'll get Error message back. Backend already knows what is wrong and has all instruments to fix it. This is bad UX. In Secrets UI it leaks the implementations details - checkbox to opt-in base64 encoding.

This PR removes the checkbox and let the backend to try to save the raw input. When it fails on bas64 encoding it'll encode the data and retry. It does it for Secrets and Configs.