### PR TITLE
HTML 5 routing

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -35,6 +35,7 @@
                  [clj-yaml "0.4.0"]
                  [cljs-ajax "0.5.8"]
                  [bidi "2.0.16"]
+                 [kibu/pushy "0.3.8"]
                  [cheshire "5.6.3"]
                  [digest "1.4.5"]
                  [environ "1.1.0"]

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
                 :figwheel     true
                 :compiler     {:main                 swarmpit.app
                                :preloads             [devtools.preload]
-                               :asset-path           "js/out"
+                               :asset-path           "/js/out"
                                :output-to            "resources/public/js/main.js"
                                :output-dir           "resources/public/js/out"
                                :infer-externs        true

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -1,20 +1,20 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>swarmpit</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0">
     <meta name="description" content="Lightweight Docker Swarm management UI">
     <meta name="theme-color" content="#ffffff">
-    <meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=0">
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500">
-    <link rel="stylesheet" href="css/main.css" type="text/css">
-    <link rel="stylesheet" href="css/rc-slider.css" type="text/css">
-    <link rel="stylesheet" href="css/codemirror.css" type="text/css">
-    <link rel="stylesheet" href="css/codemirror-lint.css" type="text/css">
-    <link rel="apple-touch-icon" sizes="180x180" href="icon/apple-touch-icon.png">
-    <link rel="icon" type="image/png" sizes="32x32" href="icon/favicon-32x32.png">
-    <link rel="icon" type="image/png" sizes="16x16" href="icon/favicon-16x16.png">
-    <link rel="mask-icon" href="icon/safari-pinned-tab.svg" color="#5bbad5">
-    <link rel="manifest" href="manifest.json">
+    <link rel="stylesheet" href="/css/main.css" type="text/css">
+    <link rel="stylesheet" href="/css/rc-slider.css" type="text/css">
+    <link rel="stylesheet" href="/css/codemirror.css" type="text/css">
+    <link rel="stylesheet" href="/css/codemirror-lint.css" type="text/css">
+    <link rel="apple-touch-icon" sizes="180x180" href="/icon/apple-touch-icon.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="/icon/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="/icon/favicon-16x16.png">
+    <link rel="mask-icon" href="/icon/safari-pinned-tab.svg" color="#5bbad5">
+    <link rel="manifest" href="/manifest.json">
 </head>
 <body>
 <div id="layout">
@@ -23,6 +23,6 @@
 </div>
 <div id="progress">
 </div>
-<script src="js/main.js" type="text/javascript"></script>
+<script src="/js/main.js" type="text/javascript"></script>
 </body>
 </html>

--- a/src/clj/swarmpit/authorization.clj
+++ b/src/clj/swarmpit/authorization.clj
@@ -52,19 +52,19 @@
              :handler any-access}
             {:pattern #"^/$"
              :handler any-access}
-            {:pattern        #"^/distribution/(dockerhub|registry)/[a-zA-Z0-9]*/repositories$"
+            {:pattern        #"^/api/distribution/(dockerhub|registry)/[a-zA-Z0-9]*/repositories$"
              :request-method :get
              :handler        {:and [authenticated-access distribution-access]}}
-            {:pattern        #"^/distribution/(dockerhub|registry)/[a-zA-Z0-9]*/tags$"
+            {:pattern        #"^/api/distribution/(dockerhub|registry)/[a-zA-Z0-9]*/tags$"
              :request-method :get
              :handler        {:and [authenticated-access distribution-access]}}
-            {:pattern        #"^/distribution/(dockerhub|registry)/[a-zA-Z0-9]*/ports$"
+            {:pattern        #"^/api/distribution/(dockerhub|registry)/[a-zA-Z0-9]*/ports$"
              :request-method :get
              :handler        {:and [authenticated-access distribution-access]}}
-            {:pattern        #"^/distribution/(dockerhub|registry)/[a-zA-Z0-9]*$"
+            {:pattern        #"^/api/distribution/(dockerhub|registry)/[a-zA-Z0-9]*$"
              :request-method #{:get :delete :post}
              :handler        {:and [authenticated-access owner-access]}}
-            {:pattern #"^/.*"
+            {:pattern #"^/api/.*"
              :handler {:and [authenticated-access]}}])
 
 (defn- rules-error

--- a/src/clj/swarmpit/server.clj
+++ b/src/clj/swarmpit/server.clj
@@ -45,7 +45,6 @@
 (def app
   (-> (make-handler routes/backend handler/dispatch)
       (wrap-resource "public")
-      (wrap-resource "react")
       wrap-authorization
       wrap-client-exception
       wrap-fallback-exception

--- a/src/cljc/swarmpit/routes.cljc
+++ b/src/cljc/swarmpit/routes.cljc
@@ -4,92 +4,95 @@
             [clojure.string :as str]))
 
 (def backend
-  ["" {"/"              {:get :index}
-       "/events"        {:get  :events
-                         :post :event-push}
-       "/version"       {:get :version}
-       "/login"         {:post :login}
-       "/slt"           {:get :slt}
-       "/password"      {:post :password}
-       "/me"            {:get :me}
-       "/api-token"     {:post   :api-token-generate
-                         :delete :api-token-remove}
-       "/repository/"   {:get {"tags"  :repository-tags
-                               "ports" :repository-ports}}
-       "/distribution/" {"public"     {:get {"/repositories" :public-repositories}}
-                         "dockerhub"  {""  {:get  :dockerhub-users
-                                            :post :dockerhub-user-create}
-                                       "/" {:get    {[:id "/repositories"] :dockerhub-repositories
-                                                     [:id]                 :dockerhub-user}
-                                            :delete {[:id] :dockerhub-user-delete}
-                                            :post   {[:id] :dockerhub-user-update}}}
-                         "registries" {""  {:get  :registries
-                                            :post :registry-create}
-                                       "/" {:get    {[:id "/repositories"] :registry-repositories
-                                                     [:id]                 :registry}
-                                            :delete {[:id] :registry-delete}
-                                            :post   {[:id] :registry-update}}}}
-       "/stacks"        {:get  :stacks
-                         :post :stack-create}
-       "/stacks/"       {:get    {[:name] {"/file"     :stack-file
-                                           "/compose"  :stack-compose
-                                           "/services" :stack-services
-                                           "/networks" :stack-networks
-                                           "/volumes"  :stack-volumes
-                                           "/configs"  :stack-configs
-                                           "/secrets"  :stack-secrets}}
-                         :delete {[:name] :stack-delete}
-                         :post   {[:name] {""          :stack-update
-                                           "/redeploy" :stack-redeploy
-                                           "/rollback" :stack-rollback}}}
-       "/services"      {:get  :services
-                         :post :service-create}
-       "/services/"     {:get    {[:id] {""          :service
-                                         "/logs"     :service-logs
-                                         "/networks" :service-networks
-                                         "/tasks"    :service-tasks
-                                         "/compose"  :service-compose}}
-                         :delete {[:id] :service-delete}
-                         :post   {[:id] {""          :service-update
-                                         "/redeploy" :service-redeploy
-                                         "/rollback" :service-rollback}}}
-       "/networks"      {:get  :networks
-                         :post :network-create}
-       "/networks/"     {:get    {[:id] {""          :network
-                                         "/services" :network-services}}
-                         :delete {[:id] :network-delete}}
-       "/volumes"       {:get  :volumes
-                         :post :volume-create}
-       "/volumes/"      {:get    {[:name] {""          :volume
-                                           "/services" :volume-services}}
-                         :delete {[:name] :volume-delete}}
-       "/secrets"       {:get  :secrets
-                         :post :secret-create}
-       "/secrets/"      {:get    {[:id] {""          :secret
-                                         "/services" :secret-services}}
-                         :delete {[:id] :secret-delete}
-                         :post   {[:id] :secret-update}}
-       "/configs"       {:get  :configs
-                         :post :config-create}
-       "/configs/"      {:get    {[:id] {""          :config
-                                         "/services" :config-services}}
-                         :delete {[:id] :config-delete}}
-       "/nodes"         {:get :nodes}
-       "/placement"     {:get :placement}
-       "/nodes/"        {:get  {[:id] {""       :node
-                                       "/tasks" :node-tasks}}
-                         :post {[:id] :node-update}}
-       "/tasks"         {:get :tasks}
-       "/tasks/"        {:get {[:id] :task}}
-       "/plugin/"       {:get {"network" :plugin-network
-                               "log"     :plugin-log
-                               "volume"  :plugin-volume}}
-       "/labels/"       {:get {"service" :labels-service}}
-       "/admin/"        {"users"  {:get  :users
-                                   :post :user-create}
-                         "users/" {:get    {[:id] :user}
-                                   :delete {[:id] :user-delete}
-                                   :post   {[:id] :user-update}}}}])
+  ["/" [["" {:get :index}]
+        ["events" {:get  :events
+                   :post :event-push}]
+        ["version" {:get :version}]
+        ["login" {:post :login
+                  :get  :index}]
+        ["slt" {:get :slt}]
+        ["password" {:post :password}]
+        ["api-token" {:get    :index
+                      :post   :api-token-generate
+                      :delete :api-token-remove}]
+        ["api"
+         {"/secrets/"      {:get    {[:id] {""          :secret
+                                            "/services" :secret-services}}
+                            :delete {[:id] :secret-delete}
+                            :post   {[:id] :secret-update}}
+          "/volumes"       {:get :volumes, :post :volume-create}
+          "/nodes/"        {:get  {[:id] {""       :node
+                                          "/tasks" :node-tasks}}
+                            :post {[:id] :node-update}}
+          "/plugin/"       {:get {"network" :plugin-network
+                                  "log"     :plugin-log
+                                  "volume"  :plugin-volume}}
+          "/tasks/"        {:get {[:id] :task}}
+          "/volumes/"      {:get    {[:name] {""          :volume
+                                              "/services" :volume-services}}
+                            :delete {[:name] :volume-delete}}
+          "/stacks"        {:get  :stacks
+                            :post :stack-create}
+          "/admin/"        {"users"  {:get  :users
+                                      :post :user-create}
+                            "users/" {:get    {[:id] :user}
+                                      :delete {[:id] :user-delete}
+                                      :post   {[:id] :user-update}}}
+          "/secrets"       {:get  :secrets
+                            :post :secret-create}
+          "/configs"       {:get  :configs
+                            :post :config-create}
+          "/distribution/" {"public"     {:get {"/repositories" :public-repositories}}
+                            "dockerhub"  {""  {:get  :dockerhub-users
+                                               :post :dockerhub-user-create}
+                                          "/" {:get    {[:id "/repositories"] :dockerhub-repositories
+                                                        [:id]                 :dockerhub-user}
+                                               :delete {[:id] :dockerhub-user-delete}
+                                               :post   {[:id] :dockerhub-user-update}}}
+                            "registries" {""  {:get  :registries
+                                               :post :registry-create}
+                                          "/" {:get    {[:id "/repositories"] :registry-repositories
+                                                        [:id]                 :registry}
+                                               :delete {[:id] :registry-delete}
+                                               :post   {[:id] :registry-update}}}}
+          "/networks"      {:get  :networks
+                            :post :network-create}
+          "/networks/"     {:get    {[:id] {""          :network
+                                            "/services" :network-services}}
+                            :delete {[:id] :network-delete}}
+          "/nodes"         {:get :nodes}
+          "/repository/"   {:get {"tags"  :repository-tags
+                                  "ports" :repository-ports}}
+          "/placement"     {:get :placement}
+          "/configs/"      {:get    {[:id] {""          :config
+                                            "/services" :config-services}}
+                            :delete {[:id] :config-delete}}
+          "/tasks"         {:get :tasks}
+          "/stacks/"       {:get    {[:name] {"/file"     :stack-file
+                                              "/compose"  :stack-compose
+                                              "/services" :stack-services
+                                              "/networks" :stack-networks
+                                              "/volumes"  :stack-volumes
+                                              "/configs"  :stack-configs
+                                              "/secrets"  :stack-secrets}}
+                            :delete {[:name] :stack-delete}
+                            :post   {[:name] {""          :stack-update
+                                              "/redeploy" :stack-redeploy
+                                              "/rollback" :stack-rollback}}}
+          "/me"            {:get :me},
+          "/services/"     {:get    {[:id] {""          :service
+                                            "/logs"     :service-logs
+                                            "/networks" :service-networks
+                                            "/tasks"    :service-tasks
+                                            "/compose"  :service-compose}}
+                            :delete {[:id] :service-delete}
+                            :post   {[:id] {""          :service-update
+                                            "/redeploy" :service-redeploy
+                                            "/rollback" :service-rollback}}}
+          "/labels/"       {:get {"service" :labels-service}}
+          "/services"      {:get  :services
+                            :post :service-create}}]
+        [true {:get :index}]]])
 
 (def frontend ["" {"/"                       :index
                    "/login"                  :login
@@ -150,4 +153,4 @@
 (defn path-for-backend
   ([handler] (path-for-backend handler {} nil))
   ([handler params] (path-for-backend handler params nil))
-  ([handler params query] (str/replace (path backend "" handler params query) #"^/" "")))
+  ([handler params query] (str/replace (path backend "/" handler params query) #"^/" "")))

--- a/src/cljc/swarmpit/routes.cljc
+++ b/src/cljc/swarmpit/routes.cljc
@@ -145,7 +145,7 @@
 (defn path-for-frontend
   ([handler] (path-for-frontend handler {} nil))
   ([handler params] (path-for-frontend handler params nil))
-  ([handler params query] (path frontend "#" handler params query)))
+  ([handler params query] (path frontend "" handler params query)))
 
 (defn path-for-backend
   ([handler] (path-for-backend handler {} nil))

--- a/src/cljs/swarmpit/app.cljs
+++ b/src/cljs/swarmpit/app.cljs
@@ -1,8 +1,7 @@
 (ns swarmpit.app
   (:require [swarmpit.router :as router]
             [swarmpit.component.layout :as layout]
-            [swarmpit.component.message :as message]
-            ))
+            [swarmpit.component.message :as message]))
 
 ;; Starting router
 

--- a/src/cljs/swarmpit/component/menu.cljs
+++ b/src/cljs/swarmpit/component/menu.cljs
@@ -115,7 +115,7 @@
             :key       (str "drawer-item-" name)
             :onClick   (fn []
                          (state/update-value [:mobileOpened] false state/layout-cursor)
-                         (dispatch! (routes/path-for-frontend handler)))}
+                         (swarmpit.router/set-location (routes/path-for-frontend handler)))}
            (when selected?
              {:className "Swarmpit-drawer-item-selected"})
            (when (= :distribution domain)
@@ -148,15 +148,11 @@
        (drawer-title-version version)]])
    (comp/divider)
    (map
-     (fn [menu-item]
-       (let [icon (:icon menu-item)
-             name (:name menu-item)
-             handler (:handler menu-item)
-             domain (:domain menu-item)
-             selected (= page-domain domain)]
+     (fn [{:keys [icon name handler domain]}]
+       (let [selected? (= page-domain domain)]
          (rum/with-key
            (if (some? icon)
-             (drawer-item name icon handler domain selected)
+             (drawer-item name icon handler domain selected?)
              (drawer-category name))
            name)))
      (let [fmenu (filter-menu docker-api)]

--- a/src/cljs/swarmpit/url.cljs
+++ b/src/cljs/swarmpit/url.cljs
@@ -3,16 +3,12 @@
 
 (defn dispatch!
   [url]
-  (-> js/document
-      .-location
-      (set! url)))
+  (set! js/document.location url))
 
 (defn url
   "Get current URL address"
   []
-  (-> js/document
-      .-location
-      .-href))
+  (-> js/document .-location .-href))
 
 (defn query-string
   "Parse query string from URL params"


### PR DESCRIPTION
Get rid of hash based routing on FE and add support for transparent routes handling on BE. This will allow us to use links to specific components via hashes. All API routes were moved under `/api` URL segment. This is Breaking Change, bud easily fixable.