### PR TITLE
Add note to env variables agent service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,9 @@ services:
     image: swarmpit/agent:latest
     environment:
       - DOCKER_API_VERSION=1.35
+      # Uncomment below if using a custom Swarmpit app service name
+      #- HEALTH_CHECK_ENDPOINT=http://app-service-name:8080/version
+      #- EVENT_ENDPOINT=http://app-service-name:8080/events
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     networks:


### PR DESCRIPTION
* Add note to env variables agent service

The agent cannot connect to Swarmpit if its service name is not the assumed `app`. This commit highlights the fact. 
See #272