### PR TITLE
Fixes scaling of the swarmpit logo on /login

### DIFF
--- a/src/cljs/swarmpit/component/page_login.cljs
+++ b/src/cljs/swarmpit/component/page_login.cljs
@@ -146,8 +146,7 @@
           {:className "Swarmpit-login-paper"}
           (html
             [:img {:src    "img/swarmpit.png"
-                   :width  "100%"
-                   :height "100%"}])
+                   :width  "100%"}])
           (html
             (progress/form (nil? initialized)
                            {:height "200px"}


### PR DESCRIPTION
Started me up a `swarmpit/swarmpit:latest` and noticed the logo is doing some weird in Chrome:

![image](https://user-images.githubusercontent.com/6037730/56759304-ea29cd80-6755-11e9-8fae-f84643a9782e.png)

Not sure if Chrome updated to be more strict about the sizing or what the deal is, but I don't think the `height "100%"` rule was intended as it's actually doing what it says now. Anywho, hope this helps. Love the project.

![image](https://user-images.githubusercontent.com/6037730/56759410-23fad400-6756-11e9-9f62-5c16cf7887df.png)

Hope I'm not being a poor contributor, but as this was a small change I didn't read _all_ of the contribution docs <3 LMK if I need to do something.