### PR TITLE
[SECURITY] Update Java 8 to latest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:8-alpine
+FROM adoptopenjdk/openjdk8:alpine-jre
 MAINTAINER Pavol Noha <pavol.noha@gmail.com>
 
 RUN apk add --update curl && \


### PR DESCRIPTION
The java:8-alpine image has not been updated for over 2 years.

This is the most official unofficial docker image for JRE 8 on Alpine.

https://hub.docker.com/r/adoptopenjdk/openjdk8