### PR TITLE
Create a 'disabled' user state

### DIFF
--- a/src/clj/swarmpit/authorization.clj
+++ b/src/clj/swarmpit/authorization.clj
@@ -2,13 +2,17 @@
   (:require [buddy.auth :refer [authenticated?]]
             [buddy.auth.accessrules :refer [success error wrap-access-rules]]
             [swarmpit.handler :refer [resp-error]]
-            [swarmpit.token :refer [admin?]]
+            [swarmpit.token :refer [admin? enabled?]]
             [swarmpit.couchdb.client :as cc]))
 
 (defn- authenticated-access
-  [request]
+  [{:keys [identity] :as request}]
   (if (authenticated? request)
-    true
+    (let [user (get-in identity [:usr])]
+      (if (enabled? user)
+        true
+        (error {:code    403
+                :message "Access by disabled user"})))
     (error {:code    401
             :message "Authentication failed"})))
 

--- a/src/cljc/swarmpit/token.cljc
+++ b/src/cljc/swarmpit/token.cljc
@@ -14,6 +14,10 @@
 #?(:cljs
    (def r (t/reader :json)))
 
+(defn enabled?
+  [user]
+  (not= "disabled" (:role user)))
+
 (defn admin?
   [user]
   (= "admin" (:role user)))

--- a/src/cljs/swarmpit/component/user/edit.cljs
+++ b/src/cljs/swarmpit/component/user/edit.cljs
@@ -42,7 +42,10 @@
        :value "admin"} "admin")
     (comp/menu-item
       {:key   "user"
-       :value "user"} "user")))
+       :value "user"} "user")
+    (comp/menu-item
+      {:key   "disabled"
+       :value "disabled"} "disabled")))
 
 
 (defn- form-email [value]


### PR DESCRIPTION
A tiny patch to the authentication flow which allows users to be put in a "disabled" state, where while technically they can get tokens they can't perform any actions.

This is useful when wiring swarmpit up as a weakly multi-tenant management UI with externally managed user creation.