### PR TITLE
Implement a real enable/disable bit for users

### DIFF
--- a/src/clj/swarmpit/couchdb/client.clj
+++ b/src/clj/swarmpit/couchdb/client.clj
@@ -320,7 +320,7 @@
 
 (defn update-user
   [user delta]
-  (let [allowed-delta (select-keys delta [:role :email])]
+  (let [allowed-delta (select-keys delta [:role :email :enabled])]
     (update-doc user allowed-delta)))
 
 (defn change-password

--- a/src/clj/swarmpit/couchdb/mapper/outbound.clj
+++ b/src/clj/swarmpit/couchdb/mapper/outbound.clj
@@ -9,7 +9,9 @@
 
 (defn ->user
   [user]
-  (assoc user :password (->password (:password user))))
+  (as-> user %
+    (update % :password ->password)
+    (update % :enabled (fnil identity true))))
 
 (defn ->dockerhub
   [docker-user docker-user-info dockeruser-namespace]

--- a/src/clj/swarmpit/handler.clj
+++ b/src/clj/swarmpit/handler.clj
@@ -83,9 +83,14 @@
       (resp-error 400 "Missing token")
       (let [user (->> (token/decode-basic token)
                       (api/user-by-credentials))]
-        (if (nil? user)
-          (resp-unauthorized "Invalid credentials")
-          (resp-ok {:token (token/generate-jwt user)}))))))
+        (cond (nil? user)
+              (resp-unauthorized "Invalid credentials")
+
+              (not (:enabled user true))
+              (resp-unauthorized "Disabled user")
+
+              :else
+              (resp-ok {:token (token/generate-jwt user)}))))))
 
 ;; Password handler
 
@@ -170,8 +175,8 @@
 
 (defn user-update
   [{{:keys [body path]} :parameters}]
-  (api/update-user (:id path) body)
-  (resp-ok))
+  (-> (api/update-user (:id path) body)
+      (resp-ok)))
 
 ;; Service handler
 

--- a/src/cljc/swarmpit/routes_spec.cljc
+++ b/src/cljc/swarmpit/routes_spec.cljc
@@ -378,6 +378,7 @@
    :role                       string?
    :type                       string?
    :username                   string?
+   :enabled                    boolean?
    :_id                        string?
    :_rev                       string?})
 

--- a/src/cljc/swarmpit/token.cljc
+++ b/src/cljc/swarmpit/token.cljc
@@ -14,6 +14,10 @@
 #?(:cljs
    (def r (t/reader :json)))
 
+(defn enabled?
+  [user]
+  (:enabled user true))
+
 (defn admin?
   [user]
   (= "admin" (:role user)))

--- a/src/cljs/swarmpit/component/user/create.cljs
+++ b/src/cljs/swarmpit/component/user/create.cljs
@@ -75,6 +75,37 @@
          :value   "admin"
          :label   "Admin"}))))
 
+(defn- form-enabled [value]
+  (comp/form-control
+    {:component "fieldset"
+     :key       "enabled-f"
+     :margin    "normal"}
+    (comp/form-label
+      {:key "rolel"} "Define whether the user is enabled")
+    (comp/form-helper-text
+      {} "Specify account enablement")
+    (comp/radio-group
+      {:name     "enabled"
+       :key      "enabled-rg"
+       :value    value
+       :onChange #(state/update-value [:enabled] (-> % .-target .-value) state/form-value-cursor)}
+      (comp/form-control-label
+        {:control (comp/radio
+                    {:name  "user-role"
+                     :color "primary"
+                     :key   "user-disabled"})
+         :key     "enabled-user"
+         :value   true
+         :label   "Enabled"})
+      (comp/form-control-label
+        {:control (comp/radio
+                    {:name  "user-disabled"
+                     :color "primary"
+                     :key   "user-disabled"})
+         :key     "enabled-user"
+         :value   false
+         :label   "Disabled"}))))
+
 (defn- form-email [value]
   (comp/text-field
     {:label           "Email"
@@ -114,7 +145,8 @@
   (state/set-value {:username ""
                     :password ""
                     :email    ""
-                    :role     "user"} state/form-value-cursor))
+                    :role     "user"
+                    :enabled  true} state/form-value-cursor))
 
 (def mixin-init-form
   (mixin/init-form
@@ -124,7 +156,7 @@
 
 (rum/defc form < rum/reactive
                  mixin-init-form [_]
-  (let [{:keys [username password role email]} (state/react state/form-value-cursor)
+  (let [{:keys [username password role enabled email]} (state/react state/form-value-cursor)
         {:keys [valid? processing? showPassword]} (state/react state/form-state-cursor)]
     (comp/mui
       (html
@@ -151,7 +183,8 @@
                 (form-username username)
                 (form-password password showPassword)
                 (form-email email)
-                (form-role role))
+                (form-role role)
+                (form-enabled enabled))
               (comp/card-actions
                 {:className "Swarmpit-fcard-actions"}
                 (composite/progress-button

--- a/src/cljs/swarmpit/component/user/edit.cljs
+++ b/src/cljs/swarmpit/component/user/edit.cljs
@@ -71,6 +71,37 @@
      :InputLabelProps {:shrink true}
      :onChange        #(state/update-value [:email] (-> % .-target .-value) state/form-value-cursor)}))
 
+(defn- form-enabled [value]
+  (comp/form-control
+    {:component "fieldset"
+     :key       "enabled-f"
+     :margin    "normal"}
+    (comp/form-label
+      {:key "rolel"} "Define whether the user is enabled")
+    (comp/form-helper-text
+      {} "Specify account enablement")
+    (comp/radio-group
+      {:name     "enabled"
+       :key      "enabled-rg"
+       :value    value
+       :onChange #(state/update-value [:enabled] (-> % .-target .-value) state/form-value-cursor)}
+      (comp/form-control-label
+        {:control (comp/radio
+                    {:name  "user-role"
+                     :color "primary"
+                     :key   "user-disabled"})
+         :key     "enabled-user"
+         :value   true
+         :label   "Enabled"})
+      (comp/form-control-label
+        {:control (comp/radio
+                    {:name  "user-disabled"
+                     :color "primary"
+                     :key   "user-disabled"})
+         :key     "enabled-user"
+         :value   false
+         :label   "Disabled"}))))
+
 (defn- user-handler
   [user-id]
   (ajax/get
@@ -107,7 +138,7 @@
       (init-form-state)
       (user-handler id))))
 
-(rum/defc form-edit < rum/static [{:keys [_id username role email]}
+(rum/defc form-edit < rum/static [{:keys [_id username role email enabled]}
                                   {:keys [processing? valid?]}]
   (comp/mui
     (html
@@ -129,7 +160,8 @@
               {:className "Swarmpit-fcard-content"}
               (form-username username)
               (form-email email)
-              (form-role role))
+              (form-role role)
+              (form-enabled enabled))
             (comp/card-actions
               {:className "Swarmpit-fcard-actions"}
               (composite/progress-button

--- a/src/cljs/swarmpit/component/user/list.cljs
+++ b/src/cljs/swarmpit/component/user/list.cljs
@@ -20,8 +20,10 @@
                       :render-fn (fn [item] (:username item))}
                      {:name      "Email"
                       :render-fn (fn [item] (:email item))}
+                     {:name      "Is enabled"
+                      :render-fn (fn [item] (if (:enabled item) "yes" "no"))}
                      {:name      "Is Admin"
-                      :render-fn (fn [item] (if (:role item) "yes" "no"))}]}
+                      :render-fn (fn [item] (if (= (:role item) "admin") "yes" "no"))}]}
    :list  {:primary   (fn [item] (:username item))
            :secondary (fn [item] (:email item))}})
 


### PR DESCRIPTION
This changeset extends the user record with an `:enabled` bit (interpreted to default to `true` for backwards compatibility) which when `false` disables user authentication.

This implements a proper back-end for #430, following up from my previous #404.