### PR TITLE
up cpu limit per service from 2 to 4

### DIFF
--- a/src/cljs/swarmpit/component/service/form_resources.cljs
+++ b/src/cljs/swarmpit/component/service/form_resources.cljs
@@ -61,7 +61,7 @@
       (comp/slider
         {:key          "cpu-limit"
          :min          0
-         :max          2
+         :max          4
          :step         0.10
          :defaultValue 0
          :value        value

--- a/src/cljs/swarmpit/component/service/form_resources.cljs
+++ b/src/cljs/swarmpit/component/service/form_resources.cljs
@@ -28,7 +28,7 @@
       (comp/slider
         {:key          "cpu-reservation"
          :min          0
-         :max          2
+         :max          4
          :step         0.10
          :defaultValue 0
          :marks        true


### PR DESCRIPTION
Fixes #531

Changing hardcoded value from 2 to 4 and letting the Docker engine handle validation check as discussed in the issue.