### PR TITLE
fix: reduce autoredeploy frecuency to once each 5 minutes

### DIFF
--- a/src/clj/swarmpit/agent.clj
+++ b/src/clj/swarmpit/agent.clj
@@ -29,6 +29,6 @@
 (defn init []
   (let [start (.plusSeconds (Instant/now) 60)]
     (chime/chime-at
-      (chime/periodic-seq start (Duration/ofMinutes 1))
+      (chime/periodic-seq start (Duration/ofMinutes 5))
       (fn [time]
         (autoredeploy-job)))))


### PR DESCRIPTION
Related to #575 

I have no enough knowledge of Closure and Swarmpit code base so I did not make it configurable, but I think that reducing 5 times the polling frequency could mitigate the issue with Docker Hub.

What do you think?