### PR TITLE
Added support for "local" logging driver

### DIFF
--- a/src/cljs/swarmpit/component/service/info/settings.cljs
+++ b/src/cljs/swarmpit/component/service/info/settings.cljs
@@ -189,7 +189,7 @@
         (comp/button
           {:size     "small"
            :color    "primary"
-           :disabled (not (contains? #{"json-file" "journald"} logdriver))
+           :disabled (not (contains? #{"json-file" "journald", "local"} logdriver))
            :href     (routes/path-for-frontend :service-info
                                                {:id (:serviceName service)}
                                                {:log 1})}

--- a/src/cljs/swarmpit/component/task/info.cljs
+++ b/src/cljs/swarmpit/component/task/info.cljs
@@ -145,7 +145,7 @@
       (comp/button
         {:size     "small"
          :color    "primary"
-         :disabled (not (contains? #{"json-file" "journald"} logdriver))
+         :disabled (not (contains? #{"json-file" "journald", "local"} logdriver))
          :href     (routes/path-for-frontend :task-info
                                              {:id id}
                                              {:log 1})}


### PR DESCRIPTION
The local logging driver has native support since Docker 1.19.3.
This new logging driver has proven to be stable and was implemented to be more efficient both at disk space consumption and when parsing and reading entire log files.

Since this is now the logging driver that Docker team recommends for most use-cases, we should support it in Swarmpit too.
Turn out, since `docker logs` has native support to it, it was just a matter of enabling the 'local' word in some places.

As the tip from official documentation says: use the “local” logging driver to prevent disk-exhaustion.

I also made an [image of swarmpit](https://hub.docker.com/r/moveyourdigital/swarmpit) with this change already in place for testing purposes.

Changes:
* https://github.com/swarmpit/swarmpit/blob/38ffbe08e717d8620bf433c99f2e85a9e5984c32/src/cljs/swarmpit/component/task/info.cljs#L148
* https://github.com/swarmpit/swarmpit/blob/38ffbe08e717d8620bf433c99f2e85a9e5984c32/src/cljs/swarmpit/component/service/info/settings.cljs#L192

References:
* [Tips on using local driver](https://docs.docker.com/config/containers/logging/configure/)
* [Local driver configuration](https://docs.docker.com/config/containers/logging/local/)