### PR TITLE
feat(ui): consider more than required as "running" and not partially running

### DIFF
--- a/src/clj/swarmpit/docker/engine/mapper/inbound.clj
+++ b/src/clj/swarmpit/docker/engine/mapper/inbound.clj
@@ -341,9 +341,9 @@
   [service-replicas-running service-replicas]
   (if (zero? service-replicas-running)
     "not running"
-    (if (= service-replicas-running service-replicas)
-      "running"
-      "partly running")))
+    (if (< service-replicas-running service-replicas)
+      "partly running"
+      "running")))
 
 (defn ->service-autoredeploy
   [service-labels]


### PR DESCRIPTION
When there are more tasks running than required by the service the UI currenly shows an orange "partially running" pill. In my opinion this should be considered "running" as well, since we have more than required.