### PR TITLE
#693 Update couchdb image to 3.3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,49 @@ docker run -it --rm \
 ### Manual installation
 Deploy Swarmpit by using a compose file from our git repo with branch of corresponding version.
 
+#### CPU architecture x86 / amd64
+
+Download this repository via git
+
 ```
 git clone https://github.com/swarmpit/swarmpit -b master
+```
+
+**Optional**: Change the password of couchdbadmin in `docker-compose.yaml`
+
+```
+OLD_PASSWORD="changeme"; read -sp "Enter new password for couchdbadmin user: " NEW_PASSWORD; echo; [ -z "$NEW_PASSWORD" ] && { echo "Password cannot be empty."; exit 1; }; sed -i "s/$OLD_PASSWORD/$NEW_PASSWORD/g" swarmpit/docker-compose.yaml && echo "Password successfully updated."
+```
+
+Deploy swarmpit stack via docker
+
+```
 docker stack deploy -c swarmpit/docker-compose.yml swarmpit
 ```
 
+#### CPU architecture arm64
+
 For ARM based cluster use custom compose file.
+
+Download this repository via git
 
 ```
 git clone https://github.com/swarmpit/swarmpit -b master
+```
+
+**Optional**: Change the password of couchdbadmin in `docker-compose.arm.yaml`
+
+```
+OLD_PASSWORD="changeme"; read -sp "Enter new password for couchdbadmin user: " NEW_PASSWORD; echo; [ -z "$NEW_PASSWORD" ] && { echo "Password cannot be empty."; exit 1; }; sed -i "s/$OLD_PASSWORD/$NEW_PASSWORD/g" swarmpit/docker-compose.arm.yaml && echo "Password successfully updated."
+```
+
+Deploy swarmpit stack via docker
+
+```
 docker stack deploy -c swarmpit/docker-compose.arm.yml swarmpit
 ```
+
+---
 
 [This stack](docker-compose.yml) is a composition of 4 services:
 

--- a/dev/script/init-db.sh
+++ b/dev/script/init-db.sh
@@ -12,5 +12,5 @@ then
     fi
 else
     echo "Creating swarmpit DB"
-    docker run -d -p 5984:5984 --name swarmpitdb couchdb:2.3.0
+    docker run -d -p 5984:5984 --name swarmpitdb couchdb:3.3.3
 fi

--- a/docker-compose.arm.yml
+++ b/docker-compose.arm.yml
@@ -4,7 +4,7 @@ services:
   app:
     image: swarmpit/swarmpit:latest
     environment:
-      - SWARMPIT_DB=http://db:5984
+      - SWARMPIT_DB=http://couchdbadmin:changeme@db:5984
       - SWARMPIT_INFLUXDB=http://influxdb:8086
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -27,7 +27,10 @@ services:
         constraints:
           - node.role == manager
   db:
-    image: treehouses/couchdb:2.3.1
+    image: arm64v8/couchdb:3.3.3
+    environment:
+      - COUCHDB_USER=couchdbadmin
+      - COUCHDB_PASSWORD=changeme
     volumes:
       - db-data:/opt/couchdb/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   app:
     image: swarmpit/swarmpit:latest
     environment:
-      - SWARMPIT_DB=http://db:5984
+      - SWARMPIT_DB=http://couchdbadmin:changeme@db:5984
       - SWARMPIT_INFLUXDB=http://influxdb:8086
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
@@ -30,7 +30,10 @@ services:
           - node.role == manager
 
   db:
-    image: couchdb:2.3.0
+    image: couchdb:3.3.3
+    environment:
+      - COUCHDB_USER=couchdbadmin
+      - COUCHDB_PASSWORD=changeme
     volumes:
       - db-data:/opt/couchdb/data
     networks:


### PR DESCRIPTION
#693 Update couchdb image to 3.3.3 to fix vulnerabilities found in couchdb version 2.3.0

In couchdb above version 3.X  it is mandatory to use a username and password, so I added the environment blocks in `docker-compose.yaml` and `docker-compose.arm.yaml` to define a couchdb username and password.

I also edited the `README.md` to advice the user to change the password of the couchdb user in the `docker-compose.yaml` or `docker-compose.arm.yaml`