### PR TITLE
fix: Update users test to handle environment variable password correctly

### DIFF
--- a/test/clj/swarmpit/config/users_test.clj
+++ b/test/clj/swarmpit/config/users_test.clj
@@ -20,10 +20,10 @@
 
   (testing "parse user with env password"
     (with-redefs [environ.core/env (fn [name] 
-                                    (when (= name :test_password) 
+                                    (when (= name :VIEWER_PASSWORD) 
                                       "envpass123"))]
       (let [user {:username "test"
-                  :password_env "TEST_PASSWORD"
+                  :password_env "VIEWER_PASSWORD"
                   :role "viewer"}
             parsed (users/parse-user-config user)]
         (is (= "test" (:username parsed)))


### PR DESCRIPTION
The deployment pipeline is broken because of a failing test. This contains the fix so all tests pass.

The main problem was that I pushed a bugfix to make sure we keep the casing for the env var (instead of looking for the lowercase version) and didn't update the test.